### PR TITLE
Limit character input in textField's and textArea's - Issue #38

### DIFF
--- a/src/edu/wright/cs/raiderplanner/controller/ActivityController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/ActivityController.java
@@ -41,6 +41,8 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter; 
+import javafx.scene.control.TextFormatter.Change; 
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.GridPane;
 import javafx.stage.Stage;
@@ -132,6 +134,19 @@ public class ActivityController implements Initializable {
 	 * Checks inputs, and unlocks the submit button if inputs are valid
 	 */
 	public void handleChange() {
+		// Limit number of char's typed in details textArea
+		this.details.setTextFormatter(new TextFormatter<String>(change -> 
+			change.getControlNewText().length() <= 400 ? change : null));
+		
+		this.name.setTextFormatter(new TextFormatter<String>(change -> 
+			change.getControlNewText().length() <= 100 ? change : null));
+		
+		this.quantity.setTextFormatter(new TextFormatter<String>(change -> 
+			change.getControlNewText().length() <= 50 ? change : null));
+		
+		this.duration.setTextFormatter(new TextFormatter<String>(change -> 
+			change.getControlNewText().length() <= 50 ? change : null));
+		
 		if (!this.name.getText().trim().isEmpty()
 				&& !this.quantity.getText().trim().isEmpty()
 				&& MainController.isNumeric(this.quantity.getText())

--- a/src/edu/wright/cs/raiderplanner/controller/RequirementController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/RequirementController.java
@@ -42,6 +42,8 @@ import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter; 
+import javafx.scene.control.TextFormatter.Change;
 import javafx.scene.control.Tooltip;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.input.MouseButton;
@@ -116,7 +118,23 @@ public class RequirementController implements Initializable {
 	/**
 	 * Handle changes to the input fields.
 	 */
+	
 	public void handleChange() {
+		// Limit number of char's typed textArea & textField
+		this.details.setTextFormatter(new TextFormatter<String>(change -> 
+			change.getControlNewText().length() <= 400 ? change : null));
+		
+		this.name.setTextFormatter(new TextFormatter<String>(change -> 
+			change.getControlNewText().length() <= 100 ? change : null));
+		
+		this.quantity.setTextFormatter(new TextFormatter<String>(change -> 
+			change.getControlNewText().length() <= 100 ? change : null));
+		
+		this.time.setTextFormatter(new TextFormatter<String>(change -> 
+			change.getControlNewText().length() <= 50 ? change : null));
+		
+		this.quantityName.setTextFormatter(new TextFormatter<String>(change -> 
+			change.getControlNewText().length() <= 100 ? change : null));
 		// Check the input fields:
 		if (!this.name.getText().trim().isEmpty()
 				&& !this.quantity.getText().trim().isEmpty()

--- a/src/edu/wright/cs/raiderplanner/controller/TaskController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/TaskController.java
@@ -55,6 +55,8 @@ import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
+import javafx.scene.control.TextFormatter.Change;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.Tooltip;
 import javafx.scene.control.cell.PropertyValueFactory;
@@ -173,6 +175,18 @@ public class TaskController implements Initializable {
 	public void handleChange() {
 		// Try to unlock:
 		unlockSubmit();
+		// Limit number of char's typed textArea & textField
+		this.details.setTextFormatter(new TextFormatter<String>(change -> 
+			change.getControlNewText().length() <= 400 ? change : null));
+		
+		this.name.setTextFormatter(new TextFormatter<String>(change -> 
+			change.getControlNewText().length() <= 100 ? change : null));
+		
+		this.weighting.setTextFormatter(new TextFormatter<String>(change -> 
+			change.getControlNewText().length() <= 50 ? change : null));
+		
+		this.taskTypeName.setTextFormatter(new TextFormatter<String>(change -> 
+			change.getControlNewText().length() <= 100 ? change : null));
 		// Process requirements and dependencies:
 		if (this.task != null) {
 			this.task.replaceDependencies(this.dependencies.getItems());


### PR DESCRIPTION
### Overview
This pull request solves issue [#38](https://github.com/gzdwsu/RaiderPlanner/issues/38). When adding an Activity, Account, or Requirement, the user is no longer able to type an infinite amount of characters during run-time into each instance of a java textField/textArea. 