### PR TITLE
Issue #84 Study Dashboard Text Not Being Replaced

### DIFF
--- a/src/edu/wright/cs/raiderplanner/controller/MenuController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/MenuController.java
@@ -350,6 +350,7 @@ public class MenuController implements Initializable {
 		this.mainContent.getChildren().remove(1, this.mainContent.getChildren().size());
 		this.topBox.getChildren().clear();
 		this.topBox.getChildren().add(this.welcome);
+		this.welcome.setText("Please select the subject to study.");
 		this.title.setText("Study Dashboard");
 
 		FlowPane modulesPane = new FlowPane();


### PR DESCRIPTION
Issue #84: Added text in Study Dashboard to prevent overlap. 

The text in the Study Dashboard now will say "Please select the subject to study." instead of being blank at the start or when the user comes back from a different tab the other tab's welcome text.