### PR TITLE
Updated index.html with new YouTube link. Closes #108

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -169,7 +169,7 @@
                     <h2 class="section-heading" style="font-size: 21px;">A short video highlighting RaiderPlanner's current features:<br></h2>
                 </div>
                 <div class="col">
-                    <div class="d-flex justify-content-center" data-aos="fade" data-aos-duration="700"><iframe width="560" height="315" allowfullscreen="" frameborder="0" src="https://www.youtube.com/embed/-tkcqaEy2HU?rel=0" style="margin-left: 0px;margin-bottom: 75px;margin-top: 5px;width: 651px;height: 423px;"></iframe></div>
+                    <div class="d-flex justify-content-center" data-aos="fade" data-aos-duration="700"><iframe width="560" height="315" allowfullscreen="" frameborder="0" src="https://www.youtube.com/embed/-4xK72rpJfc" style="margin-left: 0px;margin-bottom: 75px;margin-top: 5px;width: 651px;height: 423px;"></iframe></div>
                 </div>
             </div>
             <div class="row">


### PR DESCRIPTION
The new YouTube link directs to the updated RaiderPlanner Overview video which has a ~30% shorter duration than the original video. This closes #108.