### PR TITLE
Styled tooltips for optimization

### DIFF
--- a/src/edu/wright/cs/raiderplanner/controller/MilestoneController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/MilestoneController.java
@@ -99,10 +99,6 @@ public class MilestoneController implements Initializable {
 	@FXML private ListView<Task> tasks;
 
 	// Tooltips:
-	@FXML private Label nameTooltip;
-	@FXML private Label deadlineTooltip;
-	@FXML private Label detailsTooltip;
-	@FXML private Label tasksTooltip;
 	@FXML private Label headingTooltip;
 
 	/**
@@ -293,12 +289,12 @@ public class MilestoneController implements Initializable {
 		this.tasks.getItems().addListener((ListChangeListener<Task>) c -> handleChange());
 		// =================
 
-		// Initialize tooltip messages:
-		nameTooltip.setTooltip(new Tooltip("Enter the name of the milestone."));
-		deadlineTooltip.setTooltip(new Tooltip("Enter a deadline for the milestone \n in "
+		// Initialize tooltips:
+		name.setTooltip(new Tooltip("Enter the name of the milestone."));
+		deadline.setTooltip(new Tooltip("Enter a deadline for the milestone \n in "
 				+ "the format: MM/DD/YYYY"));
-		detailsTooltip.setTooltip(new Tooltip("Enter any details for the milestone."));
-		tasksTooltip.setTooltip(new Tooltip("Add or remove tasks from you milestone."));
+		details.setTooltip(new Tooltip("Enter any details for the milestone."));
+		tasks.setTooltip(new Tooltip("Add or remove tasks from you milestone."));
 		headingTooltip.setTooltip(new Tooltip("A Milestone is a goal that you can set for "
 				+ "yourself to achieve\nin the future.  You can "
 				+ "give a deadline and tasks\nthat need to be completed to achieve this goal."));

--- a/src/edu/wright/cs/raiderplanner/view/Milestone.fxml
+++ b/src/edu/wright/cs/raiderplanner/view/Milestone.fxml
@@ -59,52 +59,16 @@
                 <HBox prefHeight="51.0" prefWidth="219.0">
                <children>
                       <TextField fx:id="name" alignment="TOP_LEFT" onKeyReleased="#handleChange" prefColumnCount="0" prefHeight="31.0" prefWidth="305.0" promptText="Name" />
-               	<Label fx:id="nameTooltip" ellipsisString="" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="13.0" prefWidth="13.0" text="My Image">
-      				   <graphic>
-      				      <ImageView fitHeight="13.0" fitWidth="13.0" preserveRatio="true" smooth="true">
-      				        <image>
-      				          <Image url="@../content/information.png" />
-      				        </image>
-      				      </ImageView>
-      				   </graphic>
-                     <HBox.margin>
-                        <Insets left="5.0" top="5.0" />
-                     </HBox.margin>
-      				</Label>
                </children>
             </HBox>
             <HBox prefHeight="51.0" prefWidth="219.0">
                <children>
                       <DatePicker fx:id="deadline" editable="false" onAction="#validateDeadline" prefHeight="31.0" prefWidth="305.0" promptText="Deadline" />
-                  <Label fx:id="deadlineTooltip" ellipsisString="" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="13.0" prefWidth="13.0" text="My Image">
-                     <graphic>
-                        <ImageView fitHeight="13.0" fitWidth="13.0" preserveRatio="true" smooth="true">
-                           <image>
-                              <Image url="@../content/information.png" />
-                           </image>
-                        </ImageView>
-                     </graphic>
-                     <HBox.margin>
-                        <Insets left="5.0" top="5.0" />
-                     </HBox.margin>
-                  </Label>
                </children>
             </HBox>
             <HBox prefHeight="100.0" prefWidth="200.0">
                <children>
                       <TextArea fx:id="details" prefHeight="80.0" prefWidth="219.0" promptText="Details" />
-                  <Label fx:id="detailsTooltip" ellipsisString="" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="13.0" prefWidth="13.0" text="My Image">
-                     <graphic>
-                        <ImageView fitHeight="13.0" fitWidth="13.0" preserveRatio="true" smooth="true">
-                           <image>
-                              <Image url="@../content/information.png" />
-                           </image>
-                        </ImageView>
-                     </graphic>
-                     <HBox.margin>
-                        <Insets left="5.0" top="5.0" />
-                     </HBox.margin>
-                  </Label>
                </children>
             </HBox> 
             </children>
@@ -119,18 +83,6 @@
                       <Label style="-fx-text-fill: white" text="Tasks">
                      <HBox.margin>
                         <Insets />
-                     </HBox.margin>
-                  </Label>
-                  <Label fx:id="tasksTooltip" ellipsisString="" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="13.0" prefWidth="13.0" text="My Image">
-                     <graphic>
-                        <ImageView fitHeight="13.0" fitWidth="13.0" preserveRatio="true" smooth="true">
-                           <image>
-                              <Image url="@../content/information.png" />
-                           </image>
-                        </ImageView>
-                     </graphic>
-                     <HBox.margin>
-                        <Insets left="5.0" />
                      </HBox.margin>
                   </Label>
                </children>


### PR DESCRIPTION
Removed icons associated with tooltips for Add Milestone UI and instead set the tooltips on the text fields. The only icon tooltip that remained is for the heading, as there is no text field. 

Closes #163 

[ReeseProject3Pic.docx](https://github.com/gzdwsu/RaiderPlanner/files/3889791/ReeseProject3Pic.docx)
