### PR TITLE
Create account window size is more compatible with varying screen sizes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Ian Mahaffy <mahaffy.2@wright.edu>
 Don Miller <miller.189@wright.edu>
 Cole Morgan <morgan.272@wright.edu>
 Rafael Nunez <nunez.6@wright.edu>
+Tyler Palcic <palcic.4@wright.edu>
 Michael Plymire <plymire.2@wright.edu>
 Cameron Roudebush <roudebushcameron@gmail.com>
 Roberto C. Sánchez <roberto.sanchez@wright.edu>

--- a/src/edu/wright/cs/raiderplanner/view/CreateAccount.fxml
+++ b/src/edu/wright/cs/raiderplanner/view/CreateAccount.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.collections.FXCollections ?>
 
-<GridPane fx:id="pane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="232.0" prefWidth="550.0" style="-fx-background-color: #01783e;" stylesheets="@../content/stylesheet.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<GridPane fx:id="pane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="432.0" prefWidth="630.0" style="-fx-background-color: #01783e;" stylesheets="@../content/stylesheet.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <columnConstraints>
         <ColumnConstraints hgrow="SOMETIMES" minWidth="900.0" prefWidth="900.0" />
     </columnConstraints>

--- a/src/edu/wright/cs/raiderplanner/view/UiManager.java
+++ b/src/edu/wright/cs/raiderplanner/view/UiManager.java
@@ -3,7 +3,7 @@
  * Bijan Ghasemi Afshar
  *
  * Copyright (C) 2018 - Clayton D. Terrill
- * 
+ *
  * Copyright (C) 2020 - Tyler Palcic
  *
  * This program is free software: you can redistribute it and/or modify
@@ -54,6 +54,7 @@ import javafx.stage.FileChooser;
 import javafx.stage.Modality;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;

--- a/src/edu/wright/cs/raiderplanner/view/UiManager.java
+++ b/src/edu/wright/cs/raiderplanner/view/UiManager.java
@@ -50,6 +50,7 @@ import javafx.scene.SceneAntialiasing;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.scene.image.Image;
+import javafx.scene.layout.AnchorPane;
 import javafx.stage.FileChooser;
 import javafx.stage.Modality;
 import javafx.stage.Screen;
@@ -143,13 +144,8 @@ public class UiManager {
 		loader.setController(accountControl);
 		Parent root = loader.load();
 		// Set the scene:
-		Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-		double screenHeight = screenSize.getHeight();
-		double screenWidth = screenSize.getWidth();
-		double sceneHeight = screenHeight * .55;
-		double sceneWidth = screenWidth * .47;
 		Stage stage = new Stage();
-		stage.setScene(new Scene(root, sceneWidth, sceneHeight));
+		stage.setScene(new Scene(root));
 		stage.setTitle("Create Account");
 		stage.resizableProperty().setValue(false);
 		stage.getIcons().add(icon);

--- a/src/edu/wright/cs/raiderplanner/view/UiManager.java
+++ b/src/edu/wright/cs/raiderplanner/view/UiManager.java
@@ -4,8 +4,6 @@
  *
  * Copyright (C) 2018 - Clayton D. Terrill
  *
- * Copyright (C) 2020 - Tyler Palcic
- *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/src/edu/wright/cs/raiderplanner/view/UiManager.java
+++ b/src/edu/wright/cs/raiderplanner/view/UiManager.java
@@ -50,14 +50,10 @@ import javafx.scene.SceneAntialiasing;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.scene.image.Image;
-import javafx.scene.layout.AnchorPane;
 import javafx.stage.FileChooser;
 import javafx.stage.Modality;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
-
-import java.awt.Dimension;
-import java.awt.Toolkit;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;

--- a/src/edu/wright/cs/raiderplanner/view/UiManager.java
+++ b/src/edu/wright/cs/raiderplanner/view/UiManager.java
@@ -3,6 +3,8 @@
  * Bijan Ghasemi Afshar
  *
  * Copyright (C) 2018 - Clayton D. Terrill
+ * 
+ * Copyright (C) 2020 - Tyler Palcic
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -53,6 +55,8 @@ import javafx.stage.Modality;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
 
+import java.awt.Dimension;
+import java.awt.Toolkit;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -139,8 +143,13 @@ public class UiManager {
 		loader.setController(accountControl);
 		Parent root = loader.load();
 		// Set the scene:
+		Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+		double screenHeight = screenSize.getHeight();
+		double screenWidth = screenSize.getWidth();
+		double sceneHeight = screenHeight * .55;
+		double sceneWidth = screenWidth * .47;
 		Stage stage = new Stage();
-		stage.setScene(new Scene(root, 575, 432));
+		stage.setScene(new Scene(root, sceneWidth, sceneHeight));
 		stage.setTitle("Create Account");
 		stage.resizableProperty().setValue(false);
 		stage.getIcons().add(icon);


### PR DESCRIPTION
This pull request addresses issue 184. The create account window is now a more appropriate size for varying screen sizes. Before, the create account window was too small on smaller screen sizes. 

<img width="627" alt="Screen Shot 2020-02-17 at 2 57 11 PM" src="https://user-images.githubusercontent.com/25624972/74683115-e27c5f00-5195-11ea-9671-c8cdb57a339e.png">
