### PR TITLE
Issue #185 GUI Changes to ChatController and Account Creation Menu 

### DIFF
--- a/src/edu/wright/cs/raiderplanner/controller/MenuController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/MenuController.java
@@ -1180,8 +1180,7 @@ public class MenuController implements Initializable {
 		this.topBox.getChildren().clear();
 		this.title.setText("Chat");
 		this.mainContent.getChildren().addAll(firstPane);
-		
-		Window();
+		createFirstWindow();
 		submitButtonAction();
 	}
 

--- a/src/edu/wright/cs/raiderplanner/controller/MenuController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/MenuController.java
@@ -1180,7 +1180,8 @@ public class MenuController implements Initializable {
 		this.topBox.getChildren().clear();
 		this.title.setText("Chat");
 		this.mainContent.getChildren().addAll(firstPane);
-		createFirstWindow();
+		
+		Window();
 		submitButtonAction();
 	}
 
@@ -1204,12 +1205,12 @@ public class MenuController implements Initializable {
 	 * his or her username and host name and sets hint for W number format.
 	 */
 	public void createFirstWindow() {
-		logo.setFitHeight(100);
-		logo.setFitWidth(115);
+		logo.setFitHeight(400);
+		logo.setFitWidth(600);
 		logo.setImage(icon);
 		firstPane.add(logo,1,0);
 		firstPane.setMinSize(200, 200);
-		firstPane.setPadding(new Insets(10,10,10,10));
+		firstPane.setPadding(new Insets(100,100,100,150));
 		firstPane.add(name, 0, 1);
 		firstPane.add(tfName, 1, 1);
 		firstPane.add(host, 0, 2);
@@ -1220,7 +1221,7 @@ public class MenuController implements Initializable {
 		firstPane.setStyle("-fx-border-color: #cc9900");
 		firstPane.setVgap(12);
 		firstPane.setHgap(12);
-		firstPane.setAlignment(Pos.CENTER);
+		firstPane.setAlignment(Pos.BOTTOM_CENTER);
 	}
 
 	/**

--- a/src/edu/wright/cs/raiderplanner/view/CreateAccount.fxml
+++ b/src/edu/wright/cs/raiderplanner/view/CreateAccount.fxml
@@ -23,7 +23,7 @@
     </rowConstraints>
     <children>
 	<HBox GridPane.rowIndex="0">
-	    <Label fx:id="welcomeLabel" style="-fx-text-fill: white" text="Welcome to RaiderPlanner!">
+	    <Label fx:id="welcomeLabel" style="-fx-text-fill: gold" text="Welcome to RaiderPlanner!">
 		<font>
 		     <Font size="35.0" />
 	        </font>
@@ -39,7 +39,7 @@
 	</HBox>
 	
 	<HBox GridPane.rowIndex="1">
-            <Label fx:id="salutationLabel" style="-fx-text-fill: white" text="  Salutation:                             ">
+            <Label fx:id="salutationLabel" style="-fx-text-fill: gold" text="  Salutation:                             ">
                 <font>
                      <Font size="18.0" />
                 </font>
@@ -47,19 +47,19 @@
 					<Insets top="80.0" />
 				</padding>
 	    	</Label>
-	    	<Label fx:id="nameLabel" style="-fx-text-fill: white" text="   Full Name: ">
+	    	<Label fx:id="nameLabel" style="-fx-text-fill: gold" text="Full Name: ">
         		<font>
         			<Font size="18.0" />
         		</font>
         		<padding>
-        			<Insets top="80.0" left="10.0" />
+        			<Insets top="80.0" left="25.0" />
         		</padding>
 	   		</Label>
     </HBox>
 
 	<HBox GridPane.rowIndex="2">
             <children>
-                <ComboBox fx:id="salutation" prefHeight="37.0" prefWidth="220.0" promptText="Salutation" GridPane.rowIndex="2">
+                <ComboBox fx:id="salutation" prefHeight="37.0" prefWidth="100.0" promptText="Salutation" GridPane.rowIndex="2">
 	                <items>
 		                <FXCollections fx:factory="observableArrayList">
 			                <String fx:value="Mr" />
@@ -68,27 +68,40 @@
 		                </FXCollections>
 	                </items>
                     <HBox.margin>
-                        <Insets bottom="0.0" left="10.0" right="10.0" top="45.0" />
+                        <Insets bottom="0.0" left="10.0" right="132.0" top="45.0" />
                     </HBox.margin>
                 </ComboBox>
-                <TextField fx:id="fullName" alignment="TOP_LEFT" prefHeight="31.0" prefWidth="220.0" promptText="John Smith" GridPane.rowIndex="3">
+                
+                <TextField fx:id="fullName" alignment="TOP_LEFT" prefHeight="31.0" prefWidth="110.0" promptText="John" GridPane.rowIndex="1">
                     <HBox.margin>
-                        <Insets bottom="0.0" left="20.0" right="10.0" top="45.0" />
+                        <Insets bottom="10.0" left="20.0" right="10.0" top="45.0" />
 		    </HBox.margin>
 		    <font>
 	                <Font size="16.0" />
 	            </font>
                 </TextField>
+                
+                <TextField fx:id="lastName" alignment="TOP_LEFT" prefHeight="31.0" prefWidth="110.0" promptText="Smith" GridPane.rowIndex="1">
+                    <HBox.margin>
+                        <Insets bottom="10.0" left="20.0" right="10.0" top="45.0" />
+		    </HBox.margin>
+		   
+		    <font>
+	                <Font size="16.0" />
+	            </font>
+                </TextField>
+                
                 <CheckBox fx:id="famLast" mnemonicParsing="false" selected="true" text="Last Name " GridPane.rowIndex="3">
                     <HBox.margin>
                         <Insets bottom="15.0" left="5.0" right="10.0" top="60.0" />
                     </HBox.margin>
                 </CheckBox>
+                
             </children>
         </HBox>
         
 	<HBox GridPane.rowIndex="3">
-        	<Label fx:id="salutationLabel" style="-fx-text-fill: white" text="Campus Username:                   ">
+        	<Label fx:id="salutationLabel" style="-fx-text-fill: gold" text="Campus Username:                   ">
         		<font>
         			<Font size="18.0" />
         		</font>
@@ -96,7 +109,7 @@
         			<Insets top="30.0" left="10" />
         		</padding>
         	</Label>
-        	<Label fx:id="emailLabel" style="-fx-text-fill: white" text=" Email: ">
+        	<Label fx:id="emailLabel" style="-fx-text-fill: gold" text=" Email: ">
         		<font>
         			<Font size="18.0" />
         		</font>
@@ -128,7 +141,7 @@
         </HBox>
 		
 		<HBox GridPane.rowIndex="5">
-		<Label fx:id="majorLabel" style="-fx-text-fill: white" text="Major:       ">
+		<Label fx:id="majorLabel" style="-fx-text-fill: gold" text="Major:       ">
         		<font>
         			<Font size="18.0" />
         		</font>
@@ -167,7 +180,7 @@
                 </Button>
             </children>
         </HBox>
-        <Label fx:id="createAccountLabel" style="-fx-text-fill: white" text="	 Create Account">
+        <Label fx:id="createAccountLabel" style="-fx-text-fill: gold" text="	 Create Account">
             <font>
                 <Font size="31.0" />
 	    </font>


### PR DESCRIPTION
Issue:
I am proposing some aesthetic changes to the Raider Planner program. These changes include reformatted the chat window and a revised first and last name account creation window. In its current state the chat window is one dialog box in the upper left-hand corner that requires the user to input their W number and the W number of the user they are connecting with in the chat.

Completion:
I updated the first and last name text boxes in the RaiderPlanner account creation menu to better reflect the styling of the overall program. I also modified the color scheme of the account controller text to make it more uniform with the theme of the Raider Planner program. The chat controller menu was also updated to fit with the overall aesthetic of the RaiderPlanner.

Before:
![Chat Window- Before](https://user-images.githubusercontent.com/9275322/74863644-3749e200-531c-11ea-9e17-13d7a01a1b62.png)

![Account Creation Window- Before](https://user-images.githubusercontent.com/9275322/74863654-3dd85980-531c-11ea-8e7a-b209677c7a2a.png)


After:
![Chat Window- After](https://user-images.githubusercontent.com/9275322/74863683-4c267580-531c-11ea-8bc2-b1a0568abf8c.png)

![Account Creation Window- After](https://user-images.githubusercontent.com/9275322/74863697-5183c000-531c-11ea-9f52-14beece75d1f.png)
